### PR TITLE
Restore relevant Massdrop changes made in `fluxible-router` fork

### DIFF
--- a/packages/fluxible-router/lib/History.js
+++ b/packages/fluxible-router/lib/History.js
@@ -5,6 +5,8 @@
 /*global window */
 'use strict';
 
+var stateIds = require('./stateIds');
+
 var EVENT_POPSTATE = 'popstate';
 
 function isUndefined(v) {
@@ -102,7 +104,10 @@ History.prototype = {
             url = isUndefined(url) ? win.location.href : url;
 
             // remember the original url in state, so that it can be used by getUrl()
-            var _state = Object.assign({origUrl: url}, state);
+            var _state = Object.assign({
+                origUrl: url,
+                stateId: stateIds.next()
+            }, state);
             try {
                 win.history.pushState(_state, title, url);
             } catch (_) {
@@ -127,8 +132,18 @@ History.prototype = {
             title = isUndefined(title) ? win.document.title : title;
             url = isUndefined(url) ? win.location.href : url;
 
+            var newProps = {
+                origUrl: url
+            };
+
+            // We're replaceState()ing a fresh browser session (no
+            // pushState calls yet this session)
+            if (!state || !state.stateId) {
+                newProps.stateId = stateIds.next();
+            }
+
             // remember the original url in state, so that it can be used by getUrl()
-            var _state = Object.assign({origUrl: url}, state);
+            var _state = Object.assign(newProps, state);
             try {
                 win.history.replaceState(_state, title, url);
             } catch(_) {

--- a/packages/fluxible-router/lib/stateIds.js
+++ b/packages/fluxible-router/lib/stateIds.js
@@ -1,0 +1,66 @@
+/*global window */
+'use strict';
+
+// This module implements state ids (created with nextStateId) which
+// are used for imposing an ordering on History API states, useful for
+// distinguishing "popstate" events as forward or backward events by
+// comparing (isBefore) the pre- and post-popstate state ids.
+//
+// These ids only need to maintain an ordering over ids issued in the
+// same browser tab/frame's "session history". sessionStorage is
+// perfect for this (as it has wider browser support than the History
+// API), EXCEPT if sessinStorage is explicity disabled (such as in
+// Safari's private browsing mode). For that situation, we fall back
+// to timestamps, which are almost as good, barring DST changes, etc.
+//
+// A client can have multiple "visits" to our site during one "session
+// history": eg, they visit our site, navigate to some external site,
+// and then navigate to our site again.
+
+// state ids given out during the same visit are ordered by an
+// incrementing "counter" field
+var nextStateCounter = (function () {
+    var x = 0;
+    return function () {
+        return x++;
+    };
+})();
+
+// Separate visits will reset the "nextStateCounter" counters; so we
+// combine the counters with a per-visit visitId.
+var visitId = (function () {
+    var nextId;
+
+    try {
+        if (window.sessionStorage.fluxibleRouterStateId) {
+            nextId = ++window.sessionStorage.fluxibleRouterStateId;
+        } else {
+            nextId = window.sessionStorage.fluxibleRouterStateId = 1;
+        }
+    } catch (e) {
+        nextId = Date.now();
+    }
+
+    return nextId;
+})();
+
+function nextStateId() {
+    return {
+        visit: visitId,
+        counter: nextStateCounter()
+    };
+}
+
+// compare 2 state ids: return true if a was created before b
+//
+// An improper stateId object (most likely undefined) is considered to
+// always be 'before' the other. If both a and b are undefined,
+// isBefore returns false.
+function isBefore(a, b) {
+    return b && (!a || a.visit < b.visit || (a.visit === b.visit && a.counter < b.counter));
+}
+
+module.exports = {
+    next: nextStateId,
+    isBefore: isBefore
+};

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fluxible-router",
+  "name": "@massdrop/fluxible-router",
   "version": "0.4.16",
   "description": "Routing for Fluxible applications",
   "main": "index.js",

--- a/packages/fluxible-router/publish.sh
+++ b/packages/fluxible-router/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+git pull
+npm version patch
+PACKAGE=$(npm pack)
+echo PACKAGE: $PACKAGE
+curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/
+rm $PACKAGE
+git push

--- a/packages/fluxible-router/publish.sh
+++ b/packages/fluxible-router/publish.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 git pull
-npm version patch
+
+# updates the package.json to have a new version, uses version in commit msg
+VERSION=$(npm version patch)
+VERSION=$(echo $VERSION | cut -c 2-)
+
+# In a monorepo setup, `npm version patch` will not automatically create a verion
+# commit because the package.json is not in the same directory as the monorepo's
+# .git directory. As a result, we need to create the version commit.
+git add package.json
+git commit -m $VERSION
+
 PACKAGE=$(npm pack)
 echo PACKAGE: $PACKAGE
 curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/


### PR DESCRIPTION
We previously forked `fluxible-router` to make changes needed (https://github.com/Massdrop/fluxible-router). In the meantime, Fluxible moved all of its modules into a monorepo.

Now that we want to utilize an upgraded version of `fluxible-router` (to upgrade to React 15), we need to port over our existing changes to the monorepo. In addition, the changes that were made in the `mop/master` branch were pulled in.

Note that a number of fixes that we made to our `fluxible-router` fork have since been fixed upstream, and so we can move from our changes to theirs:
- Safari issuing an extra popstate nav: remove changes for https://github.com/Massdrop/fluxible-router/pull/4 and `state.fluxible` references; keep changes for https://github.com/yahoo/fluxible/pull/394 and set default for `ignorePopstateOnPageLoad` to true
- Don't update History with scroll timer: remove changes related to this from https://github.com/Massdrop/fluxible-router/pull/8; keep changes for https://github.com/yahoo/fluxible/pull/450 and set default for `saveScrollInState` to false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/fluxible/3)
<!-- Reviewable:end -->
